### PR TITLE
Add "highlight" to `scatter_plot()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: locuszoomr
 Title: Gene Locus Plot with Gene Annotations
-Version: 0.2.1
+Version: 0.2.1.9000
 Authors@R:
     c(person(given = "Myles",family = "Lewis",
     role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 News
 =====
 
+# locuszoomr 0.2.1.9000
+###### 15/03/2024
+
+* Added "highlight" to `scatter_plot()` - listed variants inherit the shape and colour of the index variant 
+
+
 # locuszoomr 0.2.1
 ###### 17/02/2024
 

--- a/R/scatter_plot.R
+++ b/R/scatter_plot.R
@@ -31,6 +31,8 @@
 #'   recombination rate data.
 #' @param legend_pos Position of legend. See [legend()]. Set to `NULL` to hide
 #'   legend.
+#' @param highlight Character vector of SNP or genomic feature IDs to highlight. 
+#'   "Highlighted" variants inherit the shape and colour of the index variant.
 #' @param labels Character vector of SNP or genomic feature IDs to label. The
 #'   value "index" selects the highest point or index SNP as defined when
 #'   [locus()] is called. Set to `NULL` to remove all labels.
@@ -65,6 +67,7 @@ scatter_plot <- function(loc,
                                        'orange', 'red', 'purple'),
                          recomb_col = "blue",
                          legend_pos = 'topleft',
+                         highlight = NULL,
                          labels = NULL,
                          label_x = 4, label_y = 4,
                          add = FALSE,
@@ -125,20 +128,25 @@ scatter_plot <- function(loc,
   pch <- rep(21L, nrow(data))
   pch[data[, loc$labs] == index_snp] <- 23L
   if ("pch" %in% colnames(data)) pch <- data$pch
+  if (!is.null(highlight))  pch[data[, loc$labs] %in% highlight] <- 23L
+  
   col <- "black"
   if ("col" %in% colnames(data)) col <- data$col
+  
+  bg = data$bg
+  if (!is.null(highlight))  bg[data[, loc$labs] %in% highlight] <- scheme[3]
   
   new.args <- list(...)
   if (add) {
     plot.args <- list(x = data[, loc$pos], y = data[, loc$yvar],
-                      pch = pch, bg = data$bg, cex = cex)
+                      pch = pch, bg = bg, cex = cex)
     if (length(new.args)) plot.args[names(new.args)] <- new.args
     return(do.call("points", plot.args))
   }
   
   bty <- if (border | recomb) 'o' else 'l'
   plot.args <- list(x = data[, loc$pos], y = data[, loc$yvar],
-               pch = pch, bg = data$bg, col = col,
+               pch = pch, bg = bg, col = col,
                las = 1, font.main = 1,
                cex = cex, cex.axis = cex.axis, cex.lab = cex.lab,
                xlim = loc$xrange,

--- a/R/scatter_plot.R
+++ b/R/scatter_plot.R
@@ -134,7 +134,10 @@ scatter_plot <- function(loc,
   if ("col" %in% colnames(data)) col <- data$col
   
   bg = data$bg
-  if (!is.null(highlight))  bg[data[, loc$labs] %in% highlight] <- scheme[3]
+  if (!is.null(highlight))  {
+    col[data[, loc$labs] %in% highlight] <- "black"
+    bg[data[, loc$labs] %in% highlight] <- scheme[3]
+  }
   
   new.args <- list(...)
   if (add) {
@@ -161,6 +164,16 @@ scatter_plot <- function(loc,
   if (length(new.args)) plot.args[names(new.args)] <- new.args
   do.call("plot", plot.args)
   
+  # replot points if "highlighted" so they are on top
+  if (!is.null(highlight))  {
+      plot.args <- list(x = data[ data[, loc$labs] %in% highlight, loc$pos], 
+                        y = data[ data[, loc$labs] %in% highlight, loc$yvar],
+                        pch = pch[ data[, loc$labs] %in% highlight ], 
+                        bg = bg[ data[, loc$labs] %in% highlight ], 
+                        col = col[ data[, loc$labs] %in% highlight ])
+      do.call("points", plot.args)
+  }
+
   # add labels
   if (!is.null(labels)) {
     i <- grep("index", labels, ignore.case = TRUE)


### PR DESCRIPTION
Hi Myles,

Really like the package. Use it often. I made a small change for a project where I wanted to "highlight" specific variants but not label them. This PR adds 1 option "highlight" to `scatter_plot()` - the listed variants inherit the shape and colour of the index variant. Useful for highlighting specific variants if one does not want the "label"

To make it work I had to slightly change how the `bg` colour is provided but overall this is a very small change.

It would be used like:

```r
library(locuszoomr)
data(SLE_gwas_sub)

library(EnsDb.Hsapiens.v75)
loc <- locus(gene = 'UBE2L3', SLE_gwas_sub, flank = 1e5, ens_db = "EnsDb.Hsapiens.v75")

highlight_rsids = c("rs3747093","rs4820091", "rs5754508", "rs112504638", "rs112504638", "rs1647705", "rs34043275", "rs762349")

# default colours
locus_plot(loc, highlight=highlight_rsids)

# personal preference scheme (defaults not ideal for highlighting as the purple gets lost in the blue)
locus_plot(loc, highlight=highlight_rsids, scheme=c("grey50","grey90","red"))
```

Default colours:
![image](https://github.com/myles-lewis/locuszoomr/assets/4245328/62b2337d-01e6-4572-a897-45be31bd5718)

Custom scheme:
![image](https://github.com/myles-lewis/locuszoomr/assets/4245328/73710ed8-d1e5-426b-b16d-4ef3d3e0a42a)


Feel free to disregard if you don't want to implement but thought I would share it in case useful.

All the best,
Luke