### PR TITLE
Two small fixes to scatter plot labelling logic

### DIFF
--- a/R/gg_scatter.R
+++ b/R/gg_scatter.R
@@ -145,7 +145,7 @@ gg_scatter <- function(loc,
   # add labels
   if (!is.null(labels)) {
     i <- grep("index", labels, ignore.case = TRUE)
-    if (i) {
+    if (length(i) > 0) {
       if (length(index_snp) == 1) {
         labels[i] <- index_snp
       } else {

--- a/R/scatter_plot.R
+++ b/R/scatter_plot.R
@@ -165,7 +165,7 @@ scatter_plot <- function(loc,
   # add labels
   if (!is.null(labels)) {
     i <- grep("index", labels, ignore.case = TRUE)
-    if (i) {
+    if (length(i) > 0) {
       if (length(index_snp) == 1) {
         labels[i] <- index_snp
       } else {


### PR DESCRIPTION
Hi Myles

There's a small bug in the logic handling labelling in `gg_scatter.R` and `scatter_plot.R` which produces the following error:

 ``` r
library(locuszoomr)
library(EnsDb.Hsapiens.v75)
data(SLE_gwas_sub)
loc <- locus(SLE_gwas_sub, gene = 'IRF5', flank = c(7e4, 2e5), LD = "r2",
            ens_db = "EnsDb.Hsapiens.v75", labs = 'rsid')
#> IRF5, chromosome 7, position 128507666 to 128790089
#> 859 SNPs/datapoints
locus_ggplot(loc, showLD = T, labels = c('rs79775079', 'rs13238352'))
#> Error in if (i) {: argument is of length zero
```

<sup>Created on 2024-04-01 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.2.0 (2022-04-22)
#>  os       Ubuntu 20.04.6 LTS
#>  system   x86_64, linux-gnu
#>  ui       X11
#>  language en_GB:
#>  collate  en_GB.UTF-8
#>  ctype    en_GB.UTF-8
#>  tz       Europe/London
#>  date     2024-04-01
#>  pandoc   2.19.2 @ /usr/lib/rstudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package              * version   date (UTC) lib source
#>  AnnotationDbi        * 1.60.0    2022-11-01 [1] Bioconductor
#>  AnnotationFilter     * 1.20.0    2022-04-26 [1] Bioconductor
#>  assertthat             0.2.1     2019-03-21 [1] CRAN (R 4.2.0)
#>  Biobase              * 2.56.0    2022-04-26 [1] Bioconductor
#>  BiocFileCache          2.4.0     2022-04-26 [1] Bioconductor
#>  BiocGenerics         * 0.42.0    2022-04-26 [1] Bioconductor
#>  BiocIO                 1.6.0     2022-04-26 [1] Bioconductor
#>  BiocParallel           1.30.0    2022-04-26 [1] Bioconductor
#>  biomaRt                2.52.0    2022-04-26 [1] Bioconductor
#>  Biostrings             2.64.1    2022-08-18 [1] Bioconductor
#>  bit                    4.0.4     2020-08-04 [1] CRAN (R 4.2.0)
#>  bit64                  4.0.5     2020-08-30 [1] CRAN (R 4.2.0)
#>  bitops                 1.0-7     2021-04-24 [1] CRAN (R 4.2.0)
#>  blob                   1.2.3     2022-04-10 [1] CRAN (R 4.2.0)
#>  cachem                 1.0.6     2021-08-19 [1] CRAN (R 4.2.0)
#>  cli                    3.6.0     2023-01-09 [1] CRAN (R 4.2.0)
#>  colorspace             2.1-0     2023-01-23 [1] CRAN (R 4.2.0)
#>  cowplot                1.1.1     2020-12-30 [1] CRAN (R 4.2.0)
#>  crayon                 1.5.1     2022-03-26 [1] CRAN (R 4.2.0)
#>  curl                   5.1.0     2023-10-02 [1] CRAN (R 4.2.0)
#>  data.table             1.14.3    2022-09-16 [1] local
#>  DBI                    1.1.2     2021-12-20 [1] CRAN (R 4.2.0)
#>  dbplyr                 2.2.1     2022-06-27 [1] CRAN (R 4.2.0)
#>  DelayedArray           0.22.0    2022-04-26 [1] Bioconductor
#>  digest                 0.6.29    2021-12-01 [1] CRAN (R 4.2.0)
#>  dplyr                  1.1.0     2023-01-29 [1] CRAN (R 4.2.0)
#>  ellipsis               0.3.2     2021-04-29 [1] CRAN (R 4.2.0)
#>  EnsDb.Hsapiens.v75   * 2.99.0    2023-12-02 [1] Bioconductor
#>  ensembldb            * 2.22.0    2022-11-01 [1] Bioconductor
#>  evaluate               0.15      2022-02-18 [1] CRAN (R 4.2.0)
#>  fansi                  1.0.4     2023-01-22 [1] CRAN (R 4.2.0)
#>  fastmap                1.1.0     2021-01-25 [1] CRAN (R 4.2.0)
#>  filelock               1.0.2     2018-10-05 [1] CRAN (R 4.2.0)
#>  fs                     1.5.2     2021-12-08 [1] CRAN (R 4.2.0)
#>  generics               0.1.3     2022-07-05 [1] CRAN (R 4.2.0)
#>  GenomeInfoDb         * 1.34.3    2022-11-10 [1] Bioconductor
#>  GenomeInfoDbData       1.2.8     2022-05-09 [1] Bioconductor
#>  GenomicAlignments      1.34.0    2022-11-01 [1] Bioconductor
#>  GenomicFeatures      * 1.50.2    2022-11-03 [1] Bioconductor
#>  GenomicRanges        * 1.48.0    2022-04-26 [1] Bioconductor
#>  gggrid                 0.2-0     2022-01-11 [1] CRAN (R 4.2.0)
#>  ggplot2                3.4.1     2023-02-10 [1] CRAN (R 4.2.0)
#>  ggrepel                0.9.3     2023-02-03 [1] CRAN (R 4.2.0)
#>  glue                   1.6.2     2022-02-24 [1] CRAN (R 4.2.0)
#>  gtable                 0.3.1     2022-09-01 [1] CRAN (R 4.2.0)
#>  hms                    1.1.2     2022-08-19 [1] CRAN (R 4.2.0)
#>  htmltools              0.5.5     2023-03-23 [1] CRAN (R 4.2.0)
#>  htmlwidgets            1.5.4     2021-09-08 [1] CRAN (R 4.2.0)
#>  httr                   1.4.7     2023-08-15 [1] CRAN (R 4.2.0)
#>  IRanges              * 2.30.1    2022-08-18 [1] Bioconductor
#>  jsonlite               1.8.0     2022-02-22 [1] CRAN (R 4.2.0)
#>  KEGGREST               1.36.3    2022-07-12 [1] Bioconductor
#>  knitr                  1.45      2023-10-30 [1] CRAN (R 4.2.0)
#>  lattice                0.20-45   2021-09-22 [2] CRAN (R 4.2.0)
#>  lazyeval               0.2.2     2019-03-15 [1] CRAN (R 4.2.0)
#>  LDlinkR                1.3.0     2023-05-31 [1] CRAN (R 4.2.0)
#>  lifecycle              1.0.3     2022-10-07 [1] CRAN (R 4.2.0)
#>  locuszoomr           * 0.2.2     2024-04-01 [1] Github (myles-lewis/locuszoomr@45fcb06)
#>  magrittr               2.0.3     2022-03-30 [1] CRAN (R 4.2.0)
#>  Matrix                 1.4-1     2022-03-23 [2] CRAN (R 4.2.0)
#>  MatrixGenerics         1.8.0     2022-04-26 [1] Bioconductor
#>  matrixStats            0.62.0    2022-04-19 [1] CRAN (R 4.2.0)
#>  memoise                2.0.1     2021-11-26 [1] CRAN (R 4.2.0)
#>  munsell                0.5.0     2018-06-12 [1] CRAN (R 4.2.0)
#>  pillar                 1.8.1     2022-08-19 [1] CRAN (R 4.2.0)
#>  pkgconfig              2.0.3     2019-09-22 [1] CRAN (R 4.2.0)
#>  plotly                 4.10.0    2021-10-09 [1] CRAN (R 4.2.0)
#>  png                    0.1-7     2013-12-03 [1] CRAN (R 4.2.0)
#>  prettyunits            1.1.1     2020-01-24 [1] CRAN (R 4.2.0)
#>  progress               1.2.2     2019-05-16 [1] CRAN (R 4.2.0)
#>  ProtGenerics           1.28.0    2022-04-26 [1] Bioconductor
#>  purrr                  1.0.1     2023-01-10 [1] CRAN (R 4.2.0)
#>  R.cache                0.16.0    2022-07-21 [1] CRAN (R 4.2.0)
#>  R.methodsS3            1.8.1     2020-08-26 [1] CRAN (R 4.2.0)
#>  R.oo                   1.24.0    2020-08-26 [1] CRAN (R 4.2.0)
#>  R.utils                2.11.0    2021-09-26 [1] CRAN (R 4.2.0)
#>  R6                     2.5.1     2021-08-19 [1] CRAN (R 4.2.0)
#>  rappdirs               0.3.3     2021-01-31 [1] CRAN (R 4.2.0)
#>  Rcpp                   1.0.10    2023-01-22 [1] CRAN (R 4.2.0)
#>  RCurl                  1.98-1.9  2022-10-03 [1] CRAN (R 4.2.0)
#>  reprex                 2.1.0     2024-01-11 [1] CRAN (R 4.2.0)
#>  restfulr               0.0.15    2022-06-16 [1] CRAN (R 4.2.0)
#>  rjson                  0.2.21    2022-01-09 [1] CRAN (R 4.2.0)
#>  rlang                  1.0.6     2022-09-24 [1] CRAN (R 4.2.0)
#>  rmarkdown              2.14      2022-04-25 [1] CRAN (R 4.2.0)
#>  Rsamtools              2.12.0    2022-04-26 [1] Bioconductor
#>  RSQLite                2.2.18    2022-10-04 [1] CRAN (R 4.2.0)
#>  rstudioapi             0.13      2020-11-12 [1] CRAN (R 4.2.0)
#>  rtracklayer            1.58.0    2022-11-01 [1] Bioconductor
#>  S4Vectors            * 0.34.0    2022-04-26 [1] Bioconductor
#>  scales                 1.2.1     2022-08-20 [1] CRAN (R 4.2.0)
#>  sessioninfo            1.2.2     2021-12-06 [1] CRAN (R 4.2.0)
#>  stringi                1.7.12    2023-01-11 [1] CRAN (R 4.2.0)
#>  stringr                1.5.0     2022-12-02 [1] CRAN (R 4.2.0)
#>  styler                 1.10.2    2023-08-29 [1] CRAN (R 4.2.0)
#>  SummarizedExperiment   1.26.1    2022-04-29 [1] Bioconductor
#>  tibble                 3.1.8     2022-07-22 [1] CRAN (R 4.2.0)
#>  tidyr                  1.3.0     2023-01-24 [1] CRAN (R 4.2.0)
#>  tidyselect             1.2.0     2022-10-10 [1] CRAN (R 4.2.0)
#>  utf8                   1.2.3     2023-01-31 [1] CRAN (R 4.2.0)
#>  vctrs                  0.5.2     2023-01-23 [1] CRAN (R 4.2.0)
#>  viridisLite            0.4.1     2022-08-22 [1] CRAN (R 4.2.0)
#>  withr                  2.5.0     2022-03-03 [1] CRAN (R 4.2.0)
#>  xfun                   0.41      2023-11-01 [1] CRAN (R 4.2.0)
#>  XML                    3.99-0.12 2022-10-28 [1] CRAN (R 4.2.0)
#>  xml2                   1.3.3     2021-11-30 [1] CRAN (R 4.2.0)
#>  XVector                0.36.0    2022-04-26 [1] Bioconductor
#>  yaml                   2.3.5     2022-02-21 [1] CRAN (R 4.2.0)
#>  zlibbioc               1.42.0    2022-04-26 [1] Bioconductor
#>  zoo                    1.8-10    2022-04-15 [1] CRAN (R 4.2.0)
#> 
#>  [1] /home/thomasw/R/x86_64-pc-linux-gnu-library/4.2
#>  [2] /home/thomasw/R/R-4.2.0/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

The culprit is the rather Pythonic `if (i)`.

Best

Tom
